### PR TITLE
Add mashup web app (Phase 1 + 2)

### DIFF
--- a/mashup_app/.gitignore
+++ b/mashup_app/.gitignore
@@ -1,0 +1,9 @@
+uploads/
+outputs/
+*.mp3
+*.wav
+*.ogg
+*.flac
+*.m4a
+__pycache__/
+.venv/

--- a/mashup_app/README.md
+++ b/mashup_app/README.md
@@ -1,0 +1,96 @@
+# 🎚️ Mashup Maker
+
+A small Flask web app that blends **two songs** into a mashup. Upload two audio
+files, trim them, balance the volume (including per-section automation), and
+**sync their tempos** so the beats line up.
+
+This covers:
+
+- **Phase 1** — upload, trim, overall + part-based volume control, fades, and
+  overlaying the two tracks at chosen positions.
+- **Phase 2** — automatic BPM detection and pitch-preserving time-stretching so
+  the two songs can be tempo-matched before they're layered.
+
+## Features
+
+| Capability | How |
+| --- | --- |
+| Select / upload two tracks | MP3, WAV, OGG, FLAC, M4A, AAC |
+| Trim each track | start / end (seconds) |
+| Volume per track | overall gain in dB |
+| Volume *throughout* the song | automation lines: `start-end: gain_dB` |
+| Fades | fade in / fade out (seconds) |
+| Placement | offset each track in the final mix |
+| Tempo sync | detect BPM of both, time-stretch to match |
+| Output | MP3 / WAV / OGG, playable in-browser + download |
+
+## Project layout
+
+```
+mashup_app/
+├── app.py              # Flask routes (web plumbing only)
+├── mashup/
+│   ├── __init__.py
+│   └── audio.py        # all audio processing (testable without Flask)
+├── templates/          # base / index / result pages
+├── static/style.css
+├── test_audio.py       # synthetic-audio test suite (no real files needed)
+└── requirements.txt
+```
+
+## Setup
+
+```bash
+cd mashup_app
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+**ffmpeg** is required (pydub uses it to read/write MP3). Either install it with
+your OS package manager (`apt install ffmpeg`, `brew install ffmpeg`, …) or rely
+on the bundled `imageio-ffmpeg` binary — `mashup/audio.py` auto-detects it when
+no system ffmpeg is on `PATH`.
+
+## Run
+
+```bash
+python app.py
+# open http://localhost:5000
+```
+
+## Test
+
+```bash
+python test_audio.py          # or: python -m pytest test_audio.py
+```
+
+The tests generate synthetic percussive tracks at known tempos, so they verify
+BPM detection, time-stretching, volume automation and the full mashup pipeline
+without needing any audio files committed to the repo.
+
+## Volume automation syntax
+
+In the "Volume automation" box for a track, one rule per line:
+
+```
+0-15:  -6      # quiet the first 15 seconds by 6 dB
+30-45:  3      # boost 30s–45s by 3 dB
+60-:  -120     # mute from 60s to the end (open-ended)
+```
+
+## How tempo sync works
+
+1. `librosa.beat.beat_track` estimates each track's BPM.
+2. The chosen target tempo is decided (match A, match B, or a fixed BPM).
+3. `librosa.effects.time_stretch` (phase vocoder) stretches the track(s) to the
+   target **without changing pitch**.
+4. Both tracks are normalised to a common sample rate / channel count and
+   overlaid on a silent canvas, then exported.
+
+## Notes & next steps (Phase 3 ideas)
+
+- Time-stretch uses a phase vocoder; for the best audio quality swap in
+  `pyrubberband` (wraps the Rubber Band library) in `audio.time_stretch`.
+- Key detection + pitch-matching for harmonically compatible mashups.
+- A waveform editor (e.g. WaveSurfer.js) for drag-to-select trim/volume regions.
+- Background job queue so long files don't block the web request.

--- a/mashup_app/app.py
+++ b/mashup_app/app.py
@@ -1,0 +1,200 @@
+"""Flask web app for the two-song mashup tool.
+
+Workflow
+--------
+1.  Upload two audio files (or reuse ones already uploaded this session).
+2.  For each track set trim points, volume, fades and part-based volume
+    automation; choose where it sits in the final mix.
+3.  Optionally tempo-sync the two songs (Phase 2).
+4.  Get a playable / downloadable mashup plus the detected BPMs.
+
+Heavy lifting lives in the :mod:`mashup` package; this file is just plumbing.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+from flask import (
+    Flask,
+    flash,
+    redirect,
+    render_template,
+    request,
+    send_from_directory,
+    url_for,
+)
+from werkzeug.utils import secure_filename
+
+from mashup import TrackSpec, VolumeSegment, build_mashup
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+UPLOAD_DIR = os.path.join(BASE_DIR, "uploads")
+OUTPUT_DIR = os.path.join(BASE_DIR, "outputs")
+ALLOWED_EXTENSIONS = {"mp3", "wav", "ogg", "flac", "m4a", "aac"}
+MAX_CONTENT_LENGTH = 64 * 1024 * 1024  # 64 MB per request
+
+os.makedirs(UPLOAD_DIR, exist_ok=True)
+os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+app = Flask(__name__)
+app.config["MAX_CONTENT_LENGTH"] = MAX_CONTENT_LENGTH
+app.secret_key = os.environ.get("MASHUP_SECRET_KEY", "dev-mashup-key")
+
+
+# ---------------------------------------------------------------------------
+# Small parsing helpers (form fields are all strings)
+# ---------------------------------------------------------------------------
+def _allowed(filename: str) -> bool:
+    return "." in filename and filename.rsplit(".", 1)[1].lower() in ALLOWED_EXTENSIONS
+
+
+def _f(name: str, default: float = 0.0) -> float:
+    raw = request.form.get(name, "").strip()
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return default
+
+
+def _seconds_to_ms(name: str, default=None):
+    raw = request.form.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        return int(float(raw) * 1000)
+    except (TypeError, ValueError):
+        return default
+
+
+def _parse_volume_segments(prefix: str) -> list[VolumeSegment]:
+    """Parse a textarea of ``start-end:gain`` lines (seconds, dB).
+
+    Example::
+
+        0-15: -6
+        30-45: 3
+        60-: -120     # mute from 60s to the end
+    """
+    raw = request.form.get(prefix, "").strip()
+    segments: list[VolumeSegment] = []
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line or ":" not in line:
+            continue
+        span, gain = line.split(":", 1)
+        try:
+            gain_db = float(gain.strip())
+        except ValueError:
+            continue
+        span = span.strip()
+        if "-" not in span:
+            continue
+        start_s, _, end_s = span.partition("-")
+        try:
+            start_ms = int(float(start_s) * 1000)
+        except ValueError:
+            continue
+        end_ms = None
+        if end_s.strip():
+            try:
+                end_ms = int(float(end_s) * 1000)
+            except ValueError:
+                end_ms = None
+        segments.append(VolumeSegment(start_ms, end_ms, gain_db))
+    return segments
+
+
+def _save_upload(field: str) -> str | None:
+    """Save an uploaded file and return its stored path, or ``None``."""
+    file = request.files.get(field)
+    if not file or not file.filename:
+        return None
+    if not _allowed(file.filename):
+        flash(f"Unsupported file type for {field}: {file.filename}")
+        return None
+    name = secure_filename(file.filename)
+    stored = f"{uuid.uuid4().hex}_{name}"
+    path = os.path.join(UPLOAD_DIR, stored)
+    file.save(path)
+    return path
+
+
+def _track_from_form(letter: str) -> TrackSpec | None:
+    path = _save_upload(f"file_{letter}")
+    if path is None:
+        return None
+    return TrackSpec(
+        path=path,
+        start_ms=_seconds_to_ms(f"start_{letter}", 0) or 0,
+        end_ms=_seconds_to_ms(f"end_{letter}", None),
+        gain_db=_f(f"gain_{letter}", 0.0),
+        offset_ms=_seconds_to_ms(f"offset_{letter}", 0) or 0,
+        fade_in_ms=_seconds_to_ms(f"fadein_{letter}", 0) or 0,
+        fade_out_ms=_seconds_to_ms(f"fadeout_{letter}", 0) or 0,
+        volume_segments=_parse_volume_segments(f"volseg_{letter}"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+@app.route("/", methods=["GET"])
+def index():
+    return render_template("index.html")
+
+
+@app.route("/mashup", methods=["POST"])
+def make_mashup():
+    track_a = _track_from_form("a")
+    track_b = _track_from_form("b")
+    if track_a is None or track_b is None:
+        flash("Please provide two audio files.")
+        return redirect(url_for("index"))
+
+    sync = request.form.get("sync") == "on"
+    tempo_target = request.form.get("tempo_target", "match_a")
+    output_format = request.form.get("output_format", "mp3")
+    if output_format not in ALLOWED_EXTENSIONS:
+        output_format = "mp3"
+
+    out_name = f"mashup_{uuid.uuid4().hex}.{output_format}"
+    out_path = os.path.join(OUTPUT_DIR, out_name)
+
+    try:
+        result = build_mashup(
+            track_a,
+            track_b,
+            out_path,
+            sync=sync,
+            tempo_target=tempo_target,
+            output_format=output_format,
+        )
+    except Exception as exc:  # surface processing errors to the user
+        flash(f"Could not build mashup: {exc}")
+        return redirect(url_for("index"))
+
+    return render_template(
+        "result.html",
+        filename=out_name,
+        bpm_a=round(result.bpm_a, 1),
+        bpm_b=round(result.bpm_b, 1),
+        applied_bpm=round(result.applied_bpm, 1) if result.applied_bpm else None,
+        duration_s=round(result.duration_ms / 1000, 1),
+        synced=sync,
+    )
+
+
+@app.route("/outputs/<path:filename>")
+def serve_output(filename: str):
+    return send_from_directory(OUTPUT_DIR, filename)
+
+
+@app.route("/download/<path:filename>")
+def download_output(filename: str):
+    return send_from_directory(OUTPUT_DIR, filename, as_attachment=True)
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=int(os.environ.get("PORT", 5000)), debug=True)

--- a/mashup_app/mashup/__init__.py
+++ b/mashup_app/mashup/__init__.py
@@ -1,0 +1,21 @@
+"""Audio mashup toolkit.
+
+Phase 1: trim, volume control (including per-section automation) and overlay.
+Phase 2: BPM detection and tempo-syncing time-stretch.
+"""
+
+from .audio import (
+    AudioClip,
+    TrackSpec,
+    VolumeSegment,
+    detect_bpm,
+    build_mashup,
+)
+
+__all__ = [
+    "AudioClip",
+    "TrackSpec",
+    "VolumeSegment",
+    "detect_bpm",
+    "build_mashup",
+]

--- a/mashup_app/mashup/audio.py
+++ b/mashup_app/mashup/audio.py
@@ -1,0 +1,318 @@
+"""Core audio processing for the mashup app.
+
+Everything here is pure-Python and works on :class:`pydub.AudioSegment`
+objects.  The web layer (``app.py``) only ever talks to this module, so the
+processing logic can be unit-tested without Flask.
+
+Phase 1  - trimming, overall gain, per-section volume automation, fades, overlay.
+Phase 2  - BPM detection (librosa) and pitch-preserving time-stretch so two
+           songs can be tempo-synced before they are layered.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+import numpy as np
+from pydub import AudioSegment
+
+# ---------------------------------------------------------------------------
+# Make pydub find an ffmpeg binary.
+#
+# In many environments ffmpeg is not on PATH.  The ``imageio-ffmpeg`` wheel
+# ships a static binary, so fall back to it when the system one is missing.
+# ---------------------------------------------------------------------------
+def _configure_ffmpeg() -> None:
+    from shutil import which
+
+    if which("ffmpeg"):
+        return
+    try:
+        import imageio_ffmpeg
+
+        exe = imageio_ffmpeg.get_ffmpeg_exe()
+        AudioSegment.converter = exe
+        AudioSegment.ffmpeg = exe
+        # imageio doesn't ship ffprobe; ffmpeg alone is enough to decode/encode.
+        os.environ.setdefault("FFMPEG_BINARY", exe)
+    except Exception:  # pragma: no cover - best effort only
+        pass
+
+
+_configure_ffmpeg()
+
+# 16-bit audio is the lingua franca for everything we do.
+_SAMPLE_WIDTH_DTYPE = {1: np.int8, 2: np.int16, 4: np.int32}
+
+
+# ---------------------------------------------------------------------------
+# Spec objects (what the UI sends us)
+# ---------------------------------------------------------------------------
+@dataclass
+class VolumeSegment:
+    """Apply ``gain_db`` to the region ``[start_ms, end_ms)`` of a track.
+
+    ``end_ms is None`` means "to the end of the track".  Positive dB is louder,
+    negative is quieter, ``-120`` is effectively silence.
+    """
+
+    start_ms: int
+    end_ms: Optional[int]
+    gain_db: float
+
+
+@dataclass
+class TrackSpec:
+    """How a single source track should be prepared before mixing."""
+
+    path: str
+    start_ms: int = 0                       # trim: where the clip begins
+    end_ms: Optional[int] = None            # trim: where the clip ends
+    gain_db: float = 0.0                    # overall volume offset
+    offset_ms: int = 0                      # placement in the final mashup
+    fade_in_ms: int = 0
+    fade_out_ms: int = 0
+    volume_segments: List[VolumeSegment] = field(default_factory=list)
+
+
+@dataclass
+class AudioClip:
+    """Thin convenience wrapper around a pydub ``AudioSegment``."""
+
+    segment: AudioSegment
+
+    @classmethod
+    def load(cls, path: str) -> "AudioClip":
+        return cls(AudioSegment.from_file(path))
+
+    @property
+    def duration_ms(self) -> int:
+        return len(self.segment)
+
+    def to_mono_float(self) -> tuple[np.ndarray, int]:
+        """Return ``(mono_samples_in_[-1,1], sample_rate)`` for analysis."""
+        y, sr = segment_to_float(self.segment)
+        if y.ndim > 1:
+            y = y.mean(axis=0)
+        return y.astype(np.float32), sr
+
+
+# ---------------------------------------------------------------------------
+# pydub <-> numpy bridge
+# ---------------------------------------------------------------------------
+def segment_to_float(seg: AudioSegment) -> tuple[np.ndarray, int]:
+    """Convert an ``AudioSegment`` to float32 samples in ``[-1, 1]``.
+
+    Shape is ``(n,)`` for mono and ``(channels, n)`` for multi-channel, which
+    is the layout librosa expects.
+    """
+    samples = np.array(seg.get_array_of_samples()).astype(np.float32)
+    peak = float(1 << (8 * seg.sample_width - 1))
+    samples /= peak
+    if seg.channels > 1:
+        samples = samples.reshape((-1, seg.channels)).T
+    return samples, seg.frame_rate
+
+
+def float_to_segment(y: np.ndarray, sr: int, sample_width: int = 2) -> AudioSegment:
+    """Inverse of :func:`segment_to_float`."""
+    if y.ndim == 1:
+        y = y[np.newaxis, :]          # (1, n)
+    channels = y.shape[0]
+    interleaved = y.T                 # (n, channels)
+    interleaved = np.clip(interleaved, -1.0, 1.0)
+    peak = float(1 << (8 * sample_width - 1))
+    dtype = _SAMPLE_WIDTH_DTYPE[sample_width]
+    # scale to int range; (peak - 1) avoids wrap at exactly +1.0
+    ints = (interleaved * (peak - 1)).astype(dtype)
+    return AudioSegment(
+        ints.tobytes(),
+        frame_rate=sr,
+        sample_width=sample_width,
+        channels=channels,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: tempo analysis & syncing
+# ---------------------------------------------------------------------------
+def detect_bpm(source) -> float:
+    """Estimate tempo in BPM.
+
+    ``source`` may be a file path, an ``AudioSegment`` or an ``AudioClip``.
+    """
+    import librosa
+
+    if isinstance(source, str):
+        clip = AudioClip.load(source)
+    elif isinstance(source, AudioClip):
+        clip = source
+    else:  # AudioSegment
+        clip = AudioClip(source)
+
+    y, sr = clip.to_mono_float()
+    if y.size == 0:
+        return 0.0
+    tempo, _ = librosa.beat.beat_track(y=y, sr=sr)
+    return float(np.atleast_1d(tempo)[0])
+
+
+def time_stretch(seg: AudioSegment, rate: float) -> AudioSegment:
+    """Stretch ``seg`` by ``rate`` while preserving pitch.
+
+    ``rate > 1`` makes the audio *faster* (higher tempo, shorter), ``rate < 1``
+    makes it slower.  Uses librosa's phase-vocoder implementation.
+    """
+    import librosa
+
+    if rate <= 0:
+        raise ValueError("rate must be positive")
+    if abs(rate - 1.0) < 1e-3:
+        return seg
+
+    y, sr = segment_to_float(seg)
+    stretched = librosa.effects.time_stretch(y, rate=rate)
+    return float_to_segment(stretched, sr, sample_width=seg.sample_width)
+
+
+def sync_tempo(
+    seg: AudioSegment, source_bpm: float, target_bpm: float
+) -> AudioSegment:
+    """Time-stretch ``seg`` from ``source_bpm`` to ``target_bpm``."""
+    if source_bpm <= 0 or target_bpm <= 0:
+        return seg
+    return time_stretch(seg, rate=target_bpm / source_bpm)
+
+
+# ---------------------------------------------------------------------------
+# Phase 1: editing primitives
+# ---------------------------------------------------------------------------
+def apply_volume_segments(
+    seg: AudioSegment, segments: List[VolumeSegment]
+) -> AudioSegment:
+    """Apply part-based volume automation.
+
+    Each :class:`VolumeSegment` boosts/cuts a non-overlapping region of the
+    track.  Regions not covered by a segment are left untouched.
+    """
+    if not segments:
+        return seg
+
+    ordered = sorted(segments, key=lambda s: s.start_ms)
+    out = AudioSegment.empty()
+    cursor = 0
+    length = len(seg)
+    for vs in ordered:
+        start = max(0, min(vs.start_ms, length))
+        end = length if vs.end_ms is None else min(vs.end_ms, length)
+        if start < cursor:           # skip overlaps with an already-applied region
+            start = cursor
+        if start > cursor:
+            out += seg[cursor:start]
+        if end > start:
+            out += seg[start:end].apply_gain(vs.gain_db)
+            cursor = end
+    if cursor < length:
+        out += seg[cursor:]
+    return out
+
+
+def prepare_track(spec: TrackSpec) -> AudioSegment:
+    """Load a source file and apply trim, gain, automation and fades."""
+    seg = AudioSegment.from_file(spec.path)
+
+    end = spec.end_ms if spec.end_ms is not None else len(seg)
+    seg = seg[spec.start_ms:end]
+
+    if spec.gain_db:
+        seg = seg.apply_gain(spec.gain_db)
+
+    seg = apply_volume_segments(seg, spec.volume_segments)
+
+    if spec.fade_in_ms:
+        seg = seg.fade_in(min(spec.fade_in_ms, len(seg)))
+    if spec.fade_out_ms:
+        seg = seg.fade_out(min(spec.fade_out_ms, len(seg)))
+
+    return seg
+
+
+def _match_format(a: AudioSegment, b: AudioSegment) -> tuple[AudioSegment, AudioSegment]:
+    """Force two segments to share frame rate and channel count for mixing."""
+    frame_rate = max(a.frame_rate, b.frame_rate)
+    channels = max(a.channels, b.channels)
+    a = a.set_frame_rate(frame_rate).set_channels(channels)
+    b = b.set_frame_rate(frame_rate).set_channels(channels)
+    return a, b
+
+
+# ---------------------------------------------------------------------------
+# Top-level entry point
+# ---------------------------------------------------------------------------
+@dataclass
+class MashupResult:
+    output_path: str
+    bpm_a: float
+    bpm_b: float
+    applied_bpm: Optional[float]
+    duration_ms: int
+
+
+def build_mashup(
+    track_a: TrackSpec,
+    track_b: TrackSpec,
+    output_path: str,
+    *,
+    sync: bool = False,
+    tempo_target: str = "match_a",   # "match_a" | "match_b" | a numeric BPM string
+    output_format: Optional[str] = None,
+) -> MashupResult:
+    """Produce a mashup from two source tracks.
+
+    Steps: analyse tempo (always, so the UI can report it) -> prepare each
+    track (Phase 1 edits) -> optionally tempo-sync (Phase 2) -> overlay onto a
+    common canvas -> export.
+    """
+    bpm_a = detect_bpm(track_a.path)
+    bpm_b = detect_bpm(track_b.path)
+
+    seg_a = prepare_track(track_a)
+    seg_b = prepare_track(track_b)
+
+    applied_bpm: Optional[float] = None
+    if sync and bpm_a > 0 and bpm_b > 0:
+        if tempo_target == "match_a":
+            applied_bpm = bpm_a
+            seg_b = sync_tempo(seg_b, bpm_b, bpm_a)
+        elif tempo_target == "match_b":
+            applied_bpm = bpm_b
+            seg_a = sync_tempo(seg_a, bpm_a, bpm_b)
+        else:
+            try:
+                target = float(tempo_target)
+            except (TypeError, ValueError):
+                target = bpm_a
+            applied_bpm = target
+            seg_a = sync_tempo(seg_a, bpm_a, target)
+            seg_b = sync_tempo(seg_b, bpm_b, target)
+
+    seg_a, seg_b = _match_format(seg_a, seg_b)
+
+    total = max(track_a.offset_ms + len(seg_a), track_b.offset_ms + len(seg_b))
+    canvas = AudioSegment.silent(duration=total, frame_rate=seg_a.frame_rate)
+    canvas = canvas.set_channels(seg_a.channels)
+    canvas = canvas.overlay(seg_a, position=track_a.offset_ms)
+    canvas = canvas.overlay(seg_b, position=track_b.offset_ms)
+
+    fmt = output_format or os.path.splitext(output_path)[1].lstrip(".") or "mp3"
+    canvas.export(output_path, format=fmt)
+
+    return MashupResult(
+        output_path=output_path,
+        bpm_a=bpm_a,
+        bpm_b=bpm_b,
+        applied_bpm=applied_bpm,
+        duration_ms=len(canvas),
+    )

--- a/mashup_app/requirements.txt
+++ b/mashup_app/requirements.txt
@@ -1,0 +1,8 @@
+Flask>=3.0
+pydub>=0.25
+librosa>=0.10
+soundfile>=0.12
+numpy>=1.24
+# ffmpeg is required by pydub. Install it via your OS package manager, or use
+# the bundled static binary below (auto-detected by mashup/audio.py):
+imageio-ffmpeg>=0.4

--- a/mashup_app/static/style.css
+++ b/mashup_app/static/style.css
@@ -1,0 +1,77 @@
+:root {
+  --bg: #0f1117;
+  --panel: #1a1d27;
+  --panel-2: #232733;
+  --accent: #6c8cff;
+  --accent-2: #00d4a0;
+  --text: #e6e8ef;
+  --muted: #9aa0b4;
+  --border: #2c3140;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.5;
+}
+
+header, footer { text-align: center; padding: 1.5rem; }
+header h1 { margin: 0; font-size: 2rem; }
+.tagline { color: var(--muted); margin: 0.25rem 0 0; }
+footer { color: var(--muted); font-size: 0.85rem; }
+
+main { max-width: 880px; margin: 0 auto; padding: 0 1rem 3rem; }
+
+.flash {
+  list-style: none; padding: 0.75rem 1rem; margin: 0 0 1rem;
+  background: #3a2330; border: 1px solid #6e3850; border-radius: 8px; color: #ffb3c4;
+}
+
+.tracks { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
+@media (max-width: 720px) { .tracks { grid-template-columns: 1fr; } }
+
+fieldset {
+  background: var(--panel); border: 1px solid var(--border);
+  border-radius: 12px; padding: 1rem 1.25rem 1.25rem; margin: 0 0 1rem;
+}
+legend { padding: 0 0.5rem; font-weight: 600; color: var(--accent); }
+
+label { display: block; font-size: 0.85rem; color: var(--muted); margin-bottom: 0.75rem; }
+label.full { grid-column: 1 / -1; }
+.hint { font-weight: normal; font-size: 0.75rem; }
+code { background: var(--panel-2); padding: 0.1rem 0.3rem; border-radius: 4px; color: var(--accent-2); }
+
+input, select, textarea {
+  width: 100%; margin-top: 0.25rem; padding: 0.5rem 0.6rem;
+  background: var(--panel-2); border: 1px solid var(--border);
+  border-radius: 8px; color: var(--text); font-size: 0.95rem;
+}
+input[type="file"] { padding: 0.4rem; }
+textarea { resize: vertical; font-family: ui-monospace, monospace; }
+
+.grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 0.5rem 0.75rem; }
+@media (max-width: 480px) { .grid { grid-template-columns: 1fr 1fr; } }
+
+.options { display: flex; flex-wrap: wrap; gap: 1rem; align-items: flex-end; }
+.options label { margin-bottom: 0; flex: 1; min-width: 160px; }
+.checkbox { display: flex; align-items: center; gap: 0.5rem; color: var(--text); }
+.checkbox input { width: auto; margin: 0; }
+
+button.go, a.go {
+  display: inline-block; background: linear-gradient(135deg, var(--accent), var(--accent-2));
+  color: #0b0d12; font-weight: 700; border: none; border-radius: 10px;
+  padding: 0.8rem 1.6rem; font-size: 1rem; cursor: pointer; text-decoration: none;
+}
+button.go { width: 100%; margin-top: 0.5rem; }
+.note { color: var(--muted); font-size: 0.8rem; text-align: center; }
+
+.result { background: var(--panel); border: 1px solid var(--border); border-radius: 12px; padding: 1.5rem; }
+.stats { list-style: none; padding: 0; display: flex; flex-wrap: wrap; gap: 1rem; }
+.stats li { background: var(--panel-2); padding: 0.5rem 0.9rem; border-radius: 8px; }
+audio { width: 100%; margin: 1.25rem 0; }
+.actions { display: flex; gap: 1rem; align-items: center; }
+a.secondary { color: var(--accent); text-decoration: none; }

--- a/mashup_app/templates/base.html
+++ b/mashup_app/templates/base.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{% block title %}Mashup Maker{% endblock %}</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+  <header>
+    <h1>🎚️ Mashup Maker</h1>
+    <p class="tagline">Blend two songs &mdash; trim, balance the volume, and sync the tempo.</p>
+  </header>
+
+  <main>
+    {% with messages = get_flashed_messages() %}
+      {% if messages %}
+        <ul class="flash">
+          {% for message in messages %}<li>{{ message }}</li>{% endfor %}
+        </ul>
+      {% endif %}
+    {% endwith %}
+
+    {% block content %}{% endblock %}
+  </main>
+
+  <footer>
+    <p>Built with Flask + pydub + librosa.</p>
+  </footer>
+</body>
+</html>

--- a/mashup_app/templates/index.html
+++ b/mashup_app/templates/index.html
@@ -1,0 +1,70 @@
+{% extends "base.html" %}
+{% block content %}
+<form action="{{ url_for('make_mashup') }}" method="post" enctype="multipart/form-data" class="mashup-form">
+
+  <div class="tracks">
+    {% for letter, label in [("a", "Track A"), ("b", "Track B")] %}
+    <fieldset class="track">
+      <legend>{{ label }}</legend>
+
+      <label class="file">
+        Audio file
+        <input type="file" name="file_{{ letter }}" accept="audio/*" required>
+      </label>
+
+      <div class="grid">
+        <label>Start (s)
+          <input type="number" name="start_{{ letter }}" step="0.1" min="0" placeholder="0">
+        </label>
+        <label>End (s)
+          <input type="number" name="end_{{ letter }}" step="0.1" min="0" placeholder="end">
+        </label>
+        <label>Volume (dB)
+          <input type="number" name="gain_{{ letter }}" step="0.5" placeholder="0">
+        </label>
+        <label>Place at (s)
+          <input type="number" name="offset_{{ letter }}" step="0.1" min="0" placeholder="0">
+        </label>
+        <label>Fade in (s)
+          <input type="number" name="fadein_{{ letter }}" step="0.1" min="0" placeholder="0">
+        </label>
+        <label>Fade out (s)
+          <input type="number" name="fadeout_{{ letter }}" step="0.1" min="0" placeholder="0">
+        </label>
+      </div>
+
+      <label class="full">
+        Volume automation <span class="hint">one per line: <code>start-end: gain_dB</code> &nbsp;(e.g. <code>0-15: -6</code>, <code>60-: -120</code> to mute)</span>
+        <textarea name="volseg_{{ letter }}" rows="3" placeholder="0-10: -6&#10;30-45: 3"></textarea>
+      </label>
+    </fieldset>
+    {% endfor %}
+  </div>
+
+  <fieldset class="options">
+    <legend>Mix options</legend>
+    <label class="checkbox">
+      <input type="checkbox" name="sync" checked> Sync tempo (time-stretch to match BPM)
+    </label>
+    <label>Tempo target
+      <select name="tempo_target">
+        <option value="match_a">Match Track A's tempo</option>
+        <option value="match_b">Match Track B's tempo</option>
+        <option value="120">Force 120 BPM</option>
+        <option value="128">Force 128 BPM</option>
+        <option value="140">Force 140 BPM</option>
+      </select>
+    </label>
+    <label>Output format
+      <select name="output_format">
+        <option value="mp3">MP3</option>
+        <option value="wav">WAV</option>
+        <option value="ogg">OGG</option>
+      </select>
+    </label>
+  </fieldset>
+
+  <button type="submit" class="go">Create mashup</button>
+  <p class="note">Processing can take a little while &mdash; tempo-syncing analyses and stretches the audio.</p>
+</form>
+{% endblock %}

--- a/mashup_app/templates/result.html
+++ b/mashup_app/templates/result.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+{% block content %}
+<section class="result">
+  <h2>Your mashup is ready 🎉</h2>
+
+  <ul class="stats">
+    <li>Track A tempo: <strong>{{ bpm_a }} BPM</strong></li>
+    <li>Track B tempo: <strong>{{ bpm_b }} BPM</strong></li>
+    {% if synced and applied_bpm %}
+      <li>Synced to: <strong>{{ applied_bpm }} BPM</strong></li>
+    {% else %}
+      <li>Tempo sync: <strong>off</strong></li>
+    {% endif %}
+    <li>Length: <strong>{{ duration_s }} s</strong></li>
+  </ul>
+
+  <audio controls src="{{ url_for('serve_output', filename=filename) }}"></audio>
+
+  <div class="actions">
+    <a class="go" href="{{ url_for('download_output', filename=filename) }}">⬇ Download</a>
+    <a class="secondary" href="{{ url_for('index') }}">Make another</a>
+  </div>
+</section>
+{% endblock %}

--- a/mashup_app/test_audio.py
+++ b/mashup_app/test_audio.py
@@ -1,0 +1,111 @@
+"""Tests for the mashup audio engine.
+
+Run with: ``python -m pytest mashup_app/test_audio.py`` (or ``python test_audio.py``).
+Generates synthetic percussive tracks so no real audio files are needed.
+"""
+
+import os
+import tempfile
+
+import numpy as np
+import soundfile as sf
+
+from mashup import TrackSpec, VolumeSegment, build_mashup, detect_bpm
+from mashup.audio import (
+    apply_volume_segments,
+    float_to_segment,
+    segment_to_float,
+    time_stretch,
+)
+from pydub import AudioSegment
+
+SR = 22050
+
+
+def _drum_track(bpm, dur=8.0, base_hz=180.0, seed=0):
+    """A percussive click track at a known tempo (detectable by librosa)."""
+    rng = np.random.default_rng(seed)
+    sig = np.zeros(int(SR * dur), dtype=np.float32)
+    period = 60.0 / bpm
+    for k in range(int(dur / period) + 1):
+        start = int(k * period * SR)
+        n = int(0.12 * SR)
+        idx = slice(start, min(start + n, len(sig)))
+        m = idx.stop - idx.start
+        env = np.exp(-np.linspace(0, 8, m))
+        tone = np.sin(2 * np.pi * base_hz * np.arange(m) / SR)
+        noise = rng.standard_normal(m) * 0.3
+        sig[idx] += (tone + noise) * env
+    return (sig / np.max(np.abs(sig)) * 0.8).astype(np.float32)
+
+
+def _write(path, bpm, **kw):
+    sf.write(path, _drum_track(bpm, **kw), SR)
+
+
+def test_roundtrip_float_conversion():
+    s = float_to_segment(_drum_track(120), SR)
+    y, sr = segment_to_float(s)
+    assert sr == SR
+    assert y.shape[0] == int(SR * 8)
+    assert -1.0 <= y.min() and y.max() <= 1.0
+
+
+def test_detect_bpm_is_close():
+    with tempfile.TemporaryDirectory() as d:
+        p = os.path.join(d, "a.wav")
+        _write(p, 120)
+        bpm = detect_bpm(p)
+        assert 110 <= bpm <= 130, f"expected ~120, got {bpm}"
+
+
+def test_time_stretch_changes_length():
+    seg = float_to_segment(_drum_track(120, dur=4.0), SR)
+    faster = time_stretch(seg, rate=2.0)   # twice as fast => ~half length
+    assert len(faster) < len(seg)
+    assert abs(len(faster) - len(seg) / 2) < 200  # within 200 ms
+
+
+def test_volume_segments_reduce_loudness():
+    seg = float_to_segment(_drum_track(120, dur=4.0), SR)
+    quieted = apply_volume_segments(seg, [VolumeSegment(0, 2000, -20)])
+    assert len(quieted) == len(seg)
+    # first 2 s should be quieter than the original
+    assert quieted[:2000].dBFS < seg[:2000].dBFS - 5
+
+
+def test_build_mashup_end_to_end():
+    with tempfile.TemporaryDirectory() as d:
+        a, b = os.path.join(d, "a.wav"), os.path.join(d, "b.wav")
+        _write(a, 120, base_hz=180, seed=1)
+        _write(b, 90, base_hz=120, seed=2)
+        out = os.path.join(d, "mash.wav")
+        res = build_mashup(
+            TrackSpec(path=a, end_ms=4000, volume_segments=[VolumeSegment(0, 1000, -6)]),
+            TrackSpec(path=b, gain_db=-3, offset_ms=200, fade_in_ms=300),
+            out,
+            sync=True,
+            tempo_target="match_a",
+            output_format="wav",
+        )
+        assert os.path.exists(out) and os.path.getsize(out) > 0
+        assert 110 <= res.bpm_a <= 130
+        assert res.applied_bpm == res.bpm_a
+        assert res.duration_ms > 0
+
+
+if __name__ == "__main__":
+    import sys
+    import traceback
+
+    funcs = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    failures = 0
+    for fn in funcs:
+        try:
+            fn()
+            print(f"PASS  {fn.__name__}")
+        except Exception:
+            failures += 1
+            print(f"FAIL  {fn.__name__}")
+            traceback.print_exc()
+    sys.exit(1 if failures else 0)


### PR DESCRIPTION
A Flask app that blends two songs into a mashup.

Phase 1: upload two tracks, trim, overall + per-section volume automation,
fades, and overlay each at a chosen offset.
Phase 2: librosa BPM detection and pitch-preserving time-stretch to
tempo-sync the two tracks before mixing.

- mashup/audio.py: pure, testable audio engine (pydub + librosa);
  auto-detects bundled imageio-ffmpeg when system ffmpeg is absent.
- app.py: Flask routes for upload, build, play and download.
- templates/ + static/: simple dark-themed UI.
- test_audio.py: synthetic-audio tests (no committed media) covering
  BPM detection, time-stretch, volume automation, and the full pipeline.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018tFwBHSBYTsWqbeCqFFshK