### PR TITLE
Add Mashup Maker: two-song mashup web app with tempo sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # 100daysofpython
+
+## Projects
+
+- **[🎚️ Mashup Maker](mashup_app/)** — a web app that blends two songs into a
+  mashup: trim, per-section volume automation, fades, and automatic tempo-sync
+  (BPM detection + pitch-preserving time-stretch). Runs locally on a Mac with
+  one command (`./run-mac.sh`) and is usable from your phone over WiFi. See
+  [mashup_app/README.md](mashup_app/README.md) for setup.

--- a/mashup_app/.dockerignore
+++ b/mashup_app/.dockerignore
@@ -1,0 +1,11 @@
+uploads/
+outputs/
+__pycache__/
+*.pyc
+.venv/
+.git/
+*.mp3
+*.wav
+*.ogg
+*.flac
+*.m4a

--- a/mashup_app/Dockerfile
+++ b/mashup_app/Dockerfile
@@ -1,0 +1,28 @@
+# Container image for the Mashup Maker web app.
+# Works on Render, Railway, Fly.io, or plain `docker run`.
+FROM python:3.11-slim
+
+# ffmpeg is required by pydub to read/write MP3, OGG, etc.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PORT=8000
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+# Uploaded sources and generated mashups (ephemeral on most hosts).
+RUN mkdir -p uploads outputs
+
+EXPOSE 8000
+
+# Long timeout: time-stretching a full song can take a while.
+# Shell form so $PORT (injected by the host) is expanded at runtime.
+CMD gunicorn app:app --bind 0.0.0.0:$PORT --workers 2 --threads 4 --timeout 300

--- a/mashup_app/README.md
+++ b/mashup_app/README.md
@@ -68,6 +68,44 @@ The tests generate synthetic percussive tracks at known tempos, so they verify
 BPM detection, time-stretching, volume automation and the full mashup pipeline
 without needing any audio files committed to the repo.
 
+## Deploy it (use it from your phone)
+
+The app is a normal responsive web page, so once it's hosted anywhere it works
+in a phone browser. **Vercel is not suitable** — it's for serverless/static
+sites, and this app needs a long-running Python server plus ffmpeg and the
+large librosa/numba stack. Use a container host instead.
+
+### Render (recommended, free tier)
+
+A `Dockerfile` and `render.yaml` are included, so:
+
+1. Push this repo to GitHub.
+2. Go to <https://render.com> → **New → Blueprint** → select this repo.
+3. Render reads `mashup_app/render.yaml`, builds the image (ffmpeg included)
+   and deploys.
+4. Open the `https://<name>.onrender.com` URL on your phone — add it to your
+   home screen for an app-like icon.
+
+The free instance sleeps after ~15 min idle (first request then takes ~30s to
+wake). Upgrade to a paid instance to keep it always-on.
+
+### Anywhere with Docker (Railway, Fly.io, a VPS)
+
+```bash
+cd mashup_app
+docker build -t mashup-maker .
+docker run -p 8000:8000 mashup-maker
+# open http://localhost:8000  (or the host's public URL)
+```
+
+The container runs `gunicorn` with a 300s timeout so long songs don't get cut
+off mid-processing.
+
+> **Note:** uploaded files and generated mashups live on the container's
+> ephemeral disk. That's fine for personal use (each mashup is produced on the
+> fly), but files won't survive a restart. Add a persistent disk / object
+> storage if you need them to stick around.
+
 ## Volume automation syntax
 
 In the "Volume automation" box for a track, one rule per line:

--- a/mashup_app/README.md
+++ b/mashup_app/README.md
@@ -34,16 +34,50 @@ mashup_app/
 │   └── audio.py        # all audio processing (testable without Flask)
 ├── templates/          # base / index / result pages
 ├── static/style.css
+├── run-mac.sh          # one-command setup + start on macOS
 ├── test_audio.py       # synthetic-audio test suite (no real files needed)
 └── requirements.txt
 ```
 
-## Setup
+## Quick start on a Mac (recommended)
+
+```bash
+git clone https://github.com/danshorstein/100daysofpython.git
+cd 100daysofpython/mashup_app
+./run-mac.sh
+```
+
+That's it. The script creates a virtualenv, installs everything (including
+ffmpeg via Homebrew if available), starts the server, and prints the URLs —
+including the one to open **on your phone** (same WiFi), e.g.
+`http://your-mac.local:5000`. Add it to your phone's home screen for an
+app-like icon.
+
+Extras:
+
+```bash
+./run-mac.sh --install-autostart   # start automatically at login, keep alive
+./run-mac.sh --remove-autostart    # undo
+brew install rubberband            # optional: studio-quality time-stretch
+                                   # (re-run ./run-mac.sh to enable)
+```
+
+To use it away from home, install [Tailscale](https://tailscale.com) (free) on
+the Mac and your phone — the same URL then works from anywhere, privately.
+
+> **A note on sharing:** this app is designed to be *run locally by each
+> person* rather than hosted publicly. Point friends at this repo and the
+> quick-start above. Everyone works with their own audio files on their own
+> machine — use songs you own or have rights to.
+
+## Manual setup (any OS)
 
 ```bash
 cd mashup_app
 python -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
+python app.py
+# open http://localhost:5000
 ```
 
 **ffmpeg** is required (pydub uses it to read/write MP3). Either install it with
@@ -51,12 +85,9 @@ your OS package manager (`apt install ffmpeg`, `brew install ffmpeg`, …) or re
 on the bundled `imageio-ffmpeg` binary — `mashup/audio.py` auto-detects it when
 no system ffmpeg is on `PATH`.
 
-## Run
-
-```bash
-python app.py
-# open http://localhost:5000
-```
+**Time-stretch quality:** if the `rubberband` CLI and `pyrubberband` are
+installed, the app automatically uses Rubber Band (noticeably cleaner); it
+falls back to librosa's phase vocoder otherwise.
 
 ## Test
 
@@ -68,12 +99,13 @@ The tests generate synthetic percussive tracks at known tempos, so they verify
 BPM detection, time-stretching, volume automation and the full mashup pipeline
 without needing any audio files committed to the repo.
 
-## Deploy it (use it from your phone)
+## Hosting it publicly (optional)
 
-The app is a normal responsive web page, so once it's hosted anywhere it works
-in a phone browser. **Vercel is not suitable** — it's for serverless/static
-sites, and this app needs a long-running Python server plus ffmpeg and the
-large librosa/numba stack. Use a container host instead.
+Running locally on your own Mac (above) is the recommended setup. But the app
+is a normal responsive web page, so it can also be hosted in the cloud if you
+ever want a public instance. **Vercel is not suitable** — it's for
+serverless/static sites, and this app needs a long-running Python server plus
+ffmpeg and the large librosa/numba stack. Use a container host instead.
 
 ### Render (recommended, free tier)
 
@@ -120,15 +152,13 @@ In the "Volume automation" box for a track, one rule per line:
 
 1. `librosa.beat.beat_track` estimates each track's BPM.
 2. The chosen target tempo is decided (match A, match B, or a fixed BPM).
-3. `librosa.effects.time_stretch` (phase vocoder) stretches the track(s) to the
-   target **without changing pitch**.
+3. The track(s) are time-stretched to the target **without changing pitch** —
+   via Rubber Band when installed, else librosa's phase vocoder.
 4. Both tracks are normalised to a common sample rate / channel count and
    overlaid on a silent canvas, then exported.
 
 ## Notes & next steps (Phase 3 ideas)
 
-- Time-stretch uses a phase vocoder; for the best audio quality swap in
-  `pyrubberband` (wraps the Rubber Band library) in `audio.time_stretch`.
 - Key detection + pitch-matching for harmonically compatible mashups.
 - A waveform editor (e.g. WaveSurfer.js) for drag-to-select trim/volume regions.
 - Background job queue so long files don't block the web request.

--- a/mashup_app/app.py
+++ b/mashup_app/app.py
@@ -197,4 +197,8 @@ def download_output(filename: str):
 
 
 if __name__ == "__main__":
-    app.run(host="0.0.0.0", port=int(os.environ.get("PORT", 5000)), debug=True)
+    app.run(
+        host="0.0.0.0",
+        port=int(os.environ.get("PORT", 5000)),
+        debug=os.environ.get("MASHUP_DEBUG") == "1",
+    )

--- a/mashup_app/mashup/audio.py
+++ b/mashup_app/mashup/audio.py
@@ -159,21 +159,49 @@ def detect_bpm(source) -> float:
     return float(np.atleast_1d(tempo)[0])
 
 
+def _rubberband_available() -> bool:
+    """True when both the ``rubberband`` CLI and pyrubberband are installed.
+
+    Rubber Band produces noticeably cleaner stretches than a phase vocoder.
+    On macOS: ``brew install rubberband && pip install pyrubberband``.
+    """
+    from shutil import which
+
+    if which("rubberband") is None:
+        return False
+    try:
+        import pyrubberband  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
 def time_stretch(seg: AudioSegment, rate: float) -> AudioSegment:
     """Stretch ``seg`` by ``rate`` while preserving pitch.
 
     ``rate > 1`` makes the audio *faster* (higher tempo, shorter), ``rate < 1``
-    makes it slower.  Uses librosa's phase-vocoder implementation.
+    makes it slower.  Prefers Rubber Band (studio quality) when installed and
+    falls back to librosa's phase vocoder otherwise.
     """
-    import librosa
-
     if rate <= 0:
         raise ValueError("rate must be positive")
     if abs(rate - 1.0) < 1e-3:
         return seg
 
     y, sr = segment_to_float(seg)
-    stretched = librosa.effects.time_stretch(y, rate=rate)
+
+    if _rubberband_available():
+        import pyrubberband
+
+        # pyrubberband wants (n,) or (n, channels); we carry (channels, n).
+        y_rb = y.T if y.ndim > 1 else y
+        stretched = pyrubberband.time_stretch(y_rb, sr, rate)
+        stretched = stretched.T if stretched.ndim > 1 else stretched
+    else:
+        import librosa
+
+        stretched = librosa.effects.time_stretch(y, rate=rate)
+
     return float_to_segment(stretched, sr, sample_width=seg.sample_width)
 
 

--- a/mashup_app/render.yaml
+++ b/mashup_app/render.yaml
@@ -1,0 +1,21 @@
+# Render Blueprint — deploy the mashup app with one click.
+#
+# How to use:
+#   1. Push this repo to GitHub (already done).
+#   2. Go to https://render.com → New → Blueprint → pick this repo.
+#   3. Render reads this file, builds the Docker image and deploys.
+#   4. Open the resulting https://<name>.onrender.com URL on your phone.
+#
+# The free plan sleeps after ~15 min idle; the first request then takes
+# ~30s to wake. Bump to a paid instance to keep it always-on.
+services:
+  - type: web
+    name: mashup-maker
+    runtime: docker
+    rootDir: mashup_app
+    dockerfilePath: ./Dockerfile
+    plan: free
+    envVars:
+      - key: MASHUP_SECRET_KEY
+        generateValue: true    # random secret for Flask sessions/flash
+    healthCheckPath: /

--- a/mashup_app/requirements.txt
+++ b/mashup_app/requirements.txt
@@ -1,4 +1,5 @@
 Flask>=3.0
+gunicorn>=21.0
 pydub>=0.25
 librosa>=0.10
 soundfile>=0.12

--- a/mashup_app/run-mac.sh
+++ b/mashup_app/run-mac.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+# One-command setup + start for Mashup Maker on macOS.
+#
+#   ./run-mac.sh                 set up (first run) and start the server
+#   ./run-mac.sh --install-autostart   also start automatically at login (launchd)
+#   ./run-mac.sh --remove-autostart    undo the above
+#
+# After it starts, open the printed URL on your phone (same WiFi network).
+
+set -e
+
+APP_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$APP_DIR"
+
+PORT="${PORT:-5000}"
+PLIST="$HOME/Library/LaunchAgents/com.mashupmaker.app.plist"
+
+# ---------------------------------------------------------------- autostart
+if [ "$1" = "--remove-autostart" ]; then
+    launchctl unload "$PLIST" 2>/dev/null || true
+    rm -f "$PLIST"
+    echo "Autostart removed."
+    exit 0
+fi
+
+# ------------------------------------------------------------------- python
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "python3 not found. Install it with:  brew install python3"
+    echo "(or get Homebrew first at https://brew.sh)"
+    exit 1
+fi
+
+# --------------------------------------------------------------- virtualenv
+if [ ! -d .venv ]; then
+    echo "Creating virtual environment..."
+    python3 -m venv .venv
+fi
+# shellcheck disable=SC1091
+source .venv/bin/activate
+
+echo "Installing/updating dependencies..."
+pip install --quiet --upgrade pip
+pip install --quiet -r requirements.txt
+
+# ------------------------------------------------- ffmpeg (needed for MP3)
+if ! command -v ffmpeg >/dev/null 2>&1; then
+    if command -v brew >/dev/null 2>&1; then
+        echo "Installing ffmpeg via Homebrew..."
+        brew install ffmpeg
+    else
+        echo "Note: ffmpeg not found and Homebrew not installed."
+        echo "Using the bundled fallback binary (imageio-ffmpeg) instead."
+    fi
+fi
+
+# ------------------------- Rubber Band (optional, better stretch quality)
+if command -v rubberband >/dev/null 2>&1; then
+    pip install --quiet pyrubberband
+    echo "Rubber Band found - using studio-quality time-stretch."
+elif command -v brew >/dev/null 2>&1; then
+    echo "Tip: 'brew install rubberband' upgrades time-stretch quality."
+    echo "     Re-run this script afterwards to enable it."
+fi
+
+# ---------------------------------------------------------------- autostart
+if [ "$1" = "--install-autostart" ]; then
+    mkdir -p "$HOME/Library/LaunchAgents"
+    cat > "$PLIST" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key><string>com.mashupmaker.app</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>$APP_DIR/.venv/bin/python</string>
+        <string>$APP_DIR/app.py</string>
+    </array>
+    <key>WorkingDirectory</key><string>$APP_DIR</string>
+    <key>EnvironmentVariables</key>
+    <dict><key>PORT</key><string>$PORT</string></dict>
+    <key>RunAtLoad</key><true/>
+    <key>KeepAlive</key><true/>
+    <key>StandardOutPath</key><string>$APP_DIR/mashup.log</string>
+    <key>StandardErrorPath</key><string>$APP_DIR/mashup.log</string>
+</dict>
+</plist>
+EOF
+    launchctl unload "$PLIST" 2>/dev/null || true
+    launchctl load "$PLIST"
+    echo "Autostart installed - Mashup Maker now runs at login (log: mashup.log)."
+    echo "It should already be up; give it a few seconds, then open:"
+else
+    echo
+    echo "Starting Mashup Maker..."
+fi
+
+# -------------------------------------------------------------- where am I?
+HOSTNAME_LOCAL="$(scutil --get LocalHostName 2>/dev/null || hostname -s)"
+LAN_IP="$(ipconfig getifaddr en0 2>/dev/null || ipconfig getifaddr en1 2>/dev/null || echo "<this-mac's-IP>")"
+
+echo
+echo "=================================================================="
+echo "  On this Mac:      http://localhost:$PORT"
+echo "  On your phone:    http://$HOSTNAME_LOCAL.local:$PORT"
+echo "        (or)        http://$LAN_IP:$PORT"
+echo "  (phone must be on the same WiFi network)"
+echo "=================================================================="
+echo
+
+if [ "$1" = "--install-autostart" ]; then
+    exit 0
+fi
+
+exec python app.py


### PR DESCRIPTION
## What this adds

**Mashup Maker** (`mashup_app/`) — a Flask web app that blends two songs into a mashup, designed to run locally (e.g. on a Mac mini) and be used from a phone over WiFi.

### Features
- Upload two audio files (MP3/WAV/OGG/FLAC/M4A/AAC)
- Trim each track, set overall volume, fades, and placement offset
- **Per-section volume automation** (`start-end: gain_dB` rules, e.g. mute a region or boost a chorus)
- **Tempo sync**: automatic BPM detection (librosa) + pitch-preserving time-stretch so the beats line up — uses Rubber Band for studio-quality stretching when installed, falls back to librosa's phase vocoder
- In-browser playback + download of the result (MP3/WAV/OGG)

### Structure
- `mashup/audio.py` — the audio engine, pure and testable without Flask
- `app.py` — thin Flask layer (upload, build, play, download)
- `templates/` + `static/` — responsive dark UI, works well on phones
- `run-mac.sh` — one-command macOS setup + start; prints the phone URL; optional `--install-autostart` (launchd)
- `Dockerfile` + `render.yaml` — optional cloud hosting path (Render/any container host)

### Testing
- `test_audio.py`: 5 tests using synthetic percussive tracks at known tempos (no audio files committed) — BPM detection accuracy, time-stretch length, volume automation, float round-trip, and the full mashup pipeline. All passing.
- End-to-end web smoke test: POST two songs → tempo-synced MP3 (detected 117.5/89.1 BPM, synced to 117.5) → download. Verified with both stretch engines (Rubber Band and librosa fallback).
- Gunicorn production boot verified (used by the Docker path).

### Notes
- Designed as a *run-it-yourself* app: each user runs it locally with their own audio files.
- Flask debug mode is opt-in (`MASHUP_DEBUG=1`) since the server is LAN-reachable.
- `run-mac.sh` was written and syntax-checked on Linux; the macOS-specific pieces (Homebrew, `scutil`, launchd) follow standard patterns but haven't run on a real Mac yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018tFwBHSBYTsWqbeCqFFshK

---
_Generated by [Claude Code](https://claude.ai/code/session_018tFwBHSBYTsWqbeCqFFshK)_