### PR TITLE
Add Grasshoppers practice mode

### DIFF
--- a/Grasshoppers/README.md
+++ b/Grasshoppers/README.md
@@ -50,6 +50,13 @@ Each grasshopper gets its own hop budget and one shot per turn — but you
 choose the order, and nothing stops you from firing every last one of them
 before you pass the turn.
 
+## Practice mode
+
+Choose **Practice** from the menu to explore an island without an opponent.
+Your swarm receives every weapon with unlimited ammo, turns have no clock or
+sudden death, and ending a turn immediately starts another player turn. It is
+ideal for learning weapon arcs and seeing how the terrain destruction behaves.
+
 ## The armory
 
 Seventeen weapons, no two mechanically alike:

--- a/Grasshoppers/index.html
+++ b/Grasshoppers/index.html
@@ -276,9 +276,13 @@
       <label>Squad</label>
       <div class="seg" id="squadseg"></div>
     </div>
-    <div class="row">
+    <div class="row" id="diffrow">
       <label>Enemy AI</label>
       <div class="seg" id="diffseg"></div>
+    </div>
+    <div class="row">
+      <label>Mode</label>
+      <div class="seg" id="modeseg"></div>
     </div>
     <div class="row">
       <label>Detail</label>
@@ -1804,7 +1808,7 @@ WEAPONS.forEach((w, i) => { w.idx = i; WBYID[w.id] = w; });
 let ammo = [{}, {}];
 function resetAmmo() {
   ammo = [{}, {}];
-  for (const t of [0, 1]) for (const w of WEAPONS) ammo[t][w.id] = w.ammo;
+  for (const t of [0, 1]) for (const w of WEAPONS) ammo[t][w.id] = practice ? -1 : w.ammo;
 }
 function haveAmmo(team, w) { return ammo[team][w.id] !== 0; }
 function useAmmo(team, w, n) {
@@ -2993,6 +2997,7 @@ let playerTeam = TEAM_A;
 let turnTeam = TEAM_A;
 let turnClock = TURN_TIME;
 let round = 1;
+let practice = false;
 let turnState = 'menu';          // menu | play | settle | over
 let settleT = 0;
 let selected = null;
@@ -3263,7 +3268,7 @@ function stepCrates(dt) {
 /* ------------------------------------------------------------- turn engine */
 function beginTurn(team) {
   turnTeam = team;
-  turnClock = TURN_TIME;
+  turnClock = practice ? Infinity : TURN_TIME;
   turnState = 'play';
   rollWind();
   for (const u of units) {
@@ -3302,6 +3307,7 @@ function settled() {
 
 function nextTurn() {
   if (checkWin()) return;
+  if (practice) { beginTurn(playerTeam); return; }
   const nt = 1 - turnTeam;
   if (nt === playerTeam) {
     round++;
@@ -3319,6 +3325,7 @@ function nextTurn() {
 }
 
 function checkWin() {
+  if (practice) return false;
   const a = aliveOf(TEAM_A).length, b = aliveOf(TEAM_B).length;
   if (a > 0 && b > 0) return false;
   turnState = 'over';
@@ -3343,9 +3350,9 @@ function updateHUD() {
   elTurnWho.textContent = turnTeam === playerTeam ? 'YOUR SWARM' : TEAMNAME[turnTeam];
   elTurnWho.style.color = turnTeam === TEAM_A ? '#b6ff3b' : '#ff5fa8';
   const c = Math.max(0, Math.ceil(turnClock));
-  elClock.textContent = turnState === 'settle' ? '…' : (c + 's');
-  elClock.className = c <= 10 ? 'low' : '';
-  elRound.textContent = 'round ' + round + (slimeY > 0 ? ' ☣' : '');
+  elClock.textContent = turnState === 'settle' ? '…' : (practice ? '∞' : (c + 's'));
+  elClock.className = !practice && c <= 10 ? 'low' : '';
+  elRound.textContent = practice ? 'PRACTICE' : ('round ' + round + (slimeY > 0 ? ' ☣' : ''));
   const wm = Math.hypot(windX, windZ);
   const arrow = windX > 1 ? '→' : windX < -1 ? '←' : '·';
   elWindTxt.textContent = 'WIND ' + arrow + ' ' + wm.toFixed(1);
@@ -3631,7 +3638,7 @@ function buildAll() {
 function placeArmies(n) {
   units.length = 0;
   const cand = spawnCandidates();
-  if (cand.length < n * 2 + 4) return false;
+  if (cand.length < (practice ? n : n * 2) + 4) return false;
   cand.sort((a, b) => a.x - b.x);
   const cut = Math.floor(cand.length * 0.38);
   let left = cand.slice(0, cut);
@@ -3653,11 +3660,12 @@ function placeArmies(n) {
       names[(team * n + i) % names.length])));
   };
   take(left, TEAM_A);
-  take(right, TEAM_B);
+  if (!practice) take(right, TEAM_B);
   return true;
 }
 
 function startGame(seed) {
+  practice = practiceMode;
   seedText = seed;
   $('gameover').classList.add('hidden');
   shots.length = 0; parts.length = 0; debris.length = 0;
@@ -3705,13 +3713,17 @@ function seg(host, items, get, set) {
   });
 }
 
-let squadIdx = 1, diffIdx = 1, qualIdx = 1;
+let squadIdx = 1, diffIdx = 1, qualIdx = 1, practiceMode = false;
 const SQUADS = [3, 5, 8];
 
 function initMenu() {
   $('seedin').value = randomSeed();
   seg($('squadseg'), SQUADS.map(n => n + ' 🦗'), () => squadIdx, i => { squadIdx = i; squadSize = SQUADS[i]; });
   seg($('diffseg'), DIFFS.map(d => d.label), () => diffIdx, i => { diffIdx = i; diff = DIFFS[i]; });
+  seg($('modeseg'), ['Battle', 'Practice'], () => practiceMode ? 1 : 0, i => {
+    practiceMode = i === 1;
+    $('diffrow').style.display = practiceMode ? 'none' : '';
+  });
   seg($('qualseg'), QUALS.map(q => q.name), () => qualIdx, i => {
     qualIdx = i; Object.assign(Q, QUALS[i]); resize();
   });

--- a/Grasshoppers/tools/test_e2e.py
+++ b/Grasshoppers/tools/test_e2e.py
@@ -71,6 +71,48 @@ def main() -> int:
         )
         assert solid_after > 0, "terrain vanished entirely — worldgen or explode() regressed"
 
+        # Practice mode: no opposing team, unlimited ammo, and each settled
+        # turn returns immediately to the player's swarm.
+        practice_page = browser.new_page(viewport={"width": 900, "height": 620})
+        practice_page.goto(PAGE)
+        practice_page.wait_for_timeout(1200)
+        practice_page.locator("#modeseg button", has_text="Practice").click()
+        practice_page.fill("#seedin", "practice-e2e-seed")
+        practice_page.click("#playbtn")
+        practice_page.wait_for_timeout(2000)
+        practice_state = practice_page.evaluate("""() => ({
+            practice,
+            state: turnState,
+            team: turnTeam,
+            enemies: aliveOf(TEAM_B).length,
+            cricketAmmo: ammo[playerTeam].cricket,
+            infiniteClock: turnClock === Infinity,
+            label: elRound.textContent
+        })""")
+        assert practice_state["practice"], f"Practice flag was not enabled: {practice_state}"
+        assert practice_state["state"] == "play" and practice_state["team"] == practice_page.evaluate("playerTeam"), \
+            f"Practice did not start as a player turn: {practice_state}"
+        assert practice_state["enemies"] == 0, f"Practice spawned enemy units: {practice_state}"
+        assert practice_state["cricketAmmo"] == -1, f"Practice ammo was limited: {practice_state}"
+        assert practice_state["infiniteClock"] and practice_state["label"] == "PRACTICE", \
+            f"Practice HUD/clock was incorrect: {practice_state}"
+
+        practice_page.evaluate("endTurn()")
+        practice_page.wait_for_timeout(600)
+        after_turn = practice_page.evaluate("({state: turnState, team: turnTeam, player: playerTeam})")
+        assert after_turn["state"] == "play" and after_turn["team"] == after_turn["player"], \
+            f"Practice advanced away from the player: {after_turn}"
+
+        practice_page.evaluate("""() => {
+            curWeapon = WBYID.cricket.idx;
+            firePower = 0.8;
+            releaseFire();
+        }""")
+        assert practice_page.evaluate("ammo[playerTeam].cricket") == -1, \
+            "Practice ammo decreased after firing"
+        practice_page.screenshot(path=str(SHOTS / "04_practice_mode.png"))
+        practice_page.close()
+
         browser.close()
 
     if errors:
@@ -79,7 +121,7 @@ def main() -> int:
             print(e, file=sys.stderr)
         return 1
 
-    print("OK — menu, match start, hop, and fire all worked with no console errors.")
+    print("OK — Battle and Practice mode flows worked with no console errors.")
     print(f"Screenshots written to {SHOTS}")
     return 0
 


### PR DESCRIPTION
## What changed

- Add a Battle/Practice menu selector; Practice hides the irrelevant enemy-AI setting.
- Start Practice with only the player swarm, unlimited weapons, an infinite turn clock, no sudden death, and player-only consecutive turns.
- Add Practice Mode documentation and extend the Playwright smoke test for the new flow.

## Why

Players can now learn weapon trajectories and freely experiment with the destructible terrain without an AI opponent or match pressure.

## Validation

- `git diff --check`
- `python3 -m py_compile Grasshoppers/tools/test_e2e.py`
- `/private/tmp/grasshoppers-playwright-venv/bin/python Grasshoppers/tools/test_e2e.py` — passed Battle and Practice flows with no console errors.
